### PR TITLE
Minimal modification to get comp rank with current private profiles

### DIFF
--- a/owapi/v3/__init__.py
+++ b/owapi/v3/__init__.py
@@ -105,7 +105,7 @@ async def get_stats(ctx: HTTPRequestContext, battletag: str):
             "stats": {},
         }
 
-        # d["stats"]["quickplay"] = parsing.bl_parse_stats(result, status=status)
+        d["stats"]["quickplay"] = parsing.bl_parse_stats(result, status=status)
         d["stats"]["competitive"] = parsing.bl_parse_stats(result, mode="competitive", status=status)
 
         built_dict[region] = d

--- a/owapi/v3/__init__.py
+++ b/owapi/v3/__init__.py
@@ -105,9 +105,7 @@ async def get_stats(ctx: HTTPRequestContext, battletag: str):
             "stats": {},
         }
 
-        print(result)
-        print(type(result))
-        d["stats"]["quickplay"] = parsing.bl_parse_stats(result, status=status)
+        # d["stats"]["quickplay"] = parsing.bl_parse_stats(result, status=status)
         d["stats"]["competitive"] = parsing.bl_parse_stats(result, mode="competitive", status=status)
 
         built_dict[region] = d

--- a/owapi/v3/__init__.py
+++ b/owapi/v3/__init__.py
@@ -98,8 +98,8 @@ async def get_stats(ctx: HTTPRequestContext, battletag: str):
             continue
 
         status = result.xpath(".//p[@class='masthead-permission-level-text']")[0].text
-        if status == "Private Profile":
-            return {"error": "Private"}, 403
+        # if status == "Private Profile":
+        #     return {"error": "Private"}, 403
 
         d = {
             "stats": {},

--- a/owapi/v3/__init__.py
+++ b/owapi/v3/__init__.py
@@ -105,9 +105,9 @@ async def get_stats(ctx: HTTPRequestContext, battletag: str):
             "stats": {},
         }
 
-        d["stats"]["quickplay"] = parsing.bl_parse_stats(result, status=status)
         print(result)
         print(type(result))
+        d["stats"]["quickplay"] = parsing.bl_parse_stats(result, status=status)
         d["stats"]["competitive"] = parsing.bl_parse_stats(result, mode="competitive", status=status)
 
         built_dict[region] = d

--- a/owapi/v3/__init__.py
+++ b/owapi/v3/__init__.py
@@ -105,8 +105,8 @@ async def get_stats(ctx: HTTPRequestContext, battletag: str):
             "stats": {},
         }
 
-        d["stats"]["quickplay"] = parsing.bl_parse_stats(result, status)
-        d["stats"]["competitive"] = parsing.bl_parse_stats(result, mode="competitive", status)
+        d["stats"]["quickplay"] = parsing.bl_parse_stats(result, status=status)
+        d["stats"]["competitive"] = parsing.bl_parse_stats(result, mode="competitive", status=status)
 
         built_dict[region] = d
 

--- a/owapi/v3/__init__.py
+++ b/owapi/v3/__init__.py
@@ -105,8 +105,8 @@ async def get_stats(ctx: HTTPRequestContext, battletag: str):
             "stats": {},
         }
 
-        d["stats"]["quickplay"] = parsing.bl_parse_stats(result)
-        d["stats"]["competitive"] = parsing.bl_parse_stats(result, mode="competitive")
+        d["stats"]["quickplay"] = parsing.bl_parse_stats(result, status)
+        d["stats"]["competitive"] = parsing.bl_parse_stats(result, mode="competitive", status)
 
         built_dict[region] = d
 

--- a/owapi/v3/__init__.py
+++ b/owapi/v3/__init__.py
@@ -106,6 +106,8 @@ async def get_stats(ctx: HTTPRequestContext, battletag: str):
         }
 
         d["stats"]["quickplay"] = parsing.bl_parse_stats(result, status=status)
+        print(result)
+        print(type(result))
         d["stats"]["competitive"] = parsing.bl_parse_stats(result, mode="competitive", status=status)
 
         built_dict[region] = d

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -72,6 +72,7 @@ def bl_parse_stats(parsed, mode="quickplay", status=None):
             comprank = int(hasrank[0].text)
         else:
             comprank = None
+        print(comprank)
         built_dict["overall_stats"]["comprank"] = comprank
         return built_dict
 

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -67,6 +67,7 @@ def bl_parse_stats(parsed, mode="quickplay"):
 
     # Shortcut location for player level etc
     mast_head = parsed.xpath(".//div[@class='masthead-player']")[0]
+    mast_head = ""
 
     # Get the prestige.
     prestige = mast_head.xpath(".//div[@class='player-level']")[0]

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -67,7 +67,7 @@ def bl_parse_stats(parsed, mode="quickplay", status=None):
 
     # Shortcut location for player level etc
     if status:
-        hasrank = mast_head.findall(".//div[@class='competitive-rank']/div")
+        hasrank = parsed.xpath(".//div[@class='masthead-player']/div[@class='competitive-rank']/div")
         if hasrank:
             comprank = int(hasrank[0].text)
         else:

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -72,7 +72,6 @@ def bl_parse_stats(parsed, mode="quickplay", status=None):
             comprank = int(hasrank[0].text)
         else:
             comprank = None
-        print(comprank)
         built_dict["overall_stats"]["comprank"] = comprank
         return built_dict
 

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -67,9 +67,9 @@ def bl_parse_stats(parsed, mode="quickplay", status=None):
 
     # Shortcut location for player level etc
     if status:
-        mast_head = parsed.xpath(".//div[@class='masthead-player']")[0]
-    else:
         mast_head = parsed.xpath(".//div[@class='masthead-player']")
+    else:
+        mast_head = parsed.xpath(".//div[@class='masthead-player']")[0]
 
     # Get the prestige.
     prestige = mast_head.xpath(".//div[@class='player-level']")[0]

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -67,7 +67,7 @@ def bl_parse_stats(parsed, mode="quickplay", status=None):
 
     # Shortcut location for player level etc
     if status:
-        hasrank = parsed.xpath(".//div[@class='masthead-player']/div[@class='competitive-rank']/div")
+        hasrank = parsed.xpath(".//div[@class='masthead-player-progression']/div[@class='competitive-rank']/div")
         if hasrank:
             comprank = int(hasrank[0].text)
         else:

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -68,6 +68,7 @@ def bl_parse_stats(parsed, mode="quickplay", status=None):
     # Shortcut location for player level etc
     if status:
         hasrank = parsed.xpath(".//div[@class='masthead-player-progression']/div[@class='competitive-rank']/div")
+        hasrank = parsed.xpath('//*[@id="overview-section"]/div/div/div/div/div[2]/div/div[3]/div')
         if hasrank:
             comprank = int(hasrank[0].text)
         else:

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -67,7 +67,6 @@ def bl_parse_stats(parsed, mode="quickplay", status=None):
 
     # Shortcut location for player level etc
     if status:
-        hasrank = parsed.xpath(".//div[@class='masthead-player-progression']/div[@class='competitive-rank']/div")
         hasrank = parsed.xpath('//*[@id="overview-section"]/div/div/div/div/div[2]/div/div[3]/div')
         if hasrank:
             comprank = int(hasrank[0].text)

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -47,7 +47,7 @@ tier_data_img_src = {
 }
 
 
-def bl_parse_stats(parsed, mode="quickplay"):
+def bl_parse_stats(parsed, mode="quickplay", status=None):
     # Just a quick FYI
     # If future me or future anyone else is looking at this, I do not how this code works.
     # I'm really really hoping it doesn't break.
@@ -66,7 +66,10 @@ def bl_parse_stats(parsed, mode="quickplay"):
     built_dict = {"game_stats": [], "overall_stats": {}, "average_stats": []}
 
     # Shortcut location for player level etc
-    mast_head = parsed.xpath(".//div[@class='masthead-player']")[0]
+    if status:
+        mast_head = parsed.xpath(".//div[@class='masthead-player']")[0]
+    else:
+        mast_head = parsed.xpath(".//div[@class='masthead-player']")
 
     # Get the prestige.
     prestige = mast_head.xpath(".//div[@class='player-level']")[0]

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -67,9 +67,15 @@ def bl_parse_stats(parsed, mode="quickplay", status=None):
 
     # Shortcut location for player level etc
     if status:
-        mast_head = parsed.xpath(".//div[@class='masthead-player']")
-    else:
-        mast_head = parsed.xpath(".//div[@class='masthead-player']")[0]
+        hasrank = mast_head.findall(".//div[@class='competitive-rank']/div")
+        if hasrank:
+            comprank = int(hasrank[0].text)
+        else:
+            comprank = None
+        built_dict["overall_stats"]["comprank"] = comprank
+        return built_dict
+
+    mast_head = parsed.xpath(".//div[@class='masthead-player']")[0]
 
     # Get the prestige.
     prestige = mast_head.xpath(".//div[@class='player-level']")[0]

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -66,7 +66,7 @@ def bl_parse_stats(parsed, mode="quickplay"):
     built_dict = {"game_stats": [], "overall_stats": {}, "average_stats": []}
 
     # Shortcut location for player level etc
-    mast_head = parsed.xpath(".//div[@class='masthead-player']")[0]
+    # mast_head = parsed.xpath(".//div[@class='masthead-player']")[0]
     mast_head = ""
 
     # Get the prestige.

--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -66,8 +66,7 @@ def bl_parse_stats(parsed, mode="quickplay"):
     built_dict = {"game_stats": [], "overall_stats": {}, "average_stats": []}
 
     # Shortcut location for player level etc
-    # mast_head = parsed.xpath(".//div[@class='masthead-player']")[0]
-    mast_head = ""
+    mast_head = parsed.xpath(".//div[@class='masthead-player']")[0]
 
     # Get the prestige.
     prestige = mast_head.xpath(".//div[@class='player-level']")[0]


### PR DESCRIPTION
If profile is private, then we get the comp rank from a specific xpath and return the resulting dict.
I didn't have time nor the need to check if there was other informations "gettable" from the current private profiles, but it works for the competitive ranking.