### PR TITLE
Fix parsing of wins, losses, and ties.

### DIFF
--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -190,10 +190,10 @@ def bl_parse_stats(parsed, mode="quickplay", status=None):
 
     # Highlight specific stat groups.
     try:
-        game_box = stat_groups[5]
+        game_box = stat_groups[3]
     except IndexError:
         try:
-            game_box = stat_groups[4]
+            game_box = stat_groups[2] # I guess use 2?
         except IndexError:
             # edge cases...
             # we can't really extract any more stats
@@ -215,10 +215,9 @@ def bl_parse_stats(parsed, mode="quickplay", status=None):
 
     if mode == "competitive":
         try:
-            misc_box = stat_groups[7]
-            losses = int(misc_box.xpath(".//text()[. = 'Games Lost']/../..")[0][1].text
+            losses = int(game_box.xpath(".//text()[. = 'Games Lost']/../..")[0][1].text
                          .replace(",", ""))
-            ties = int(misc_box.xpath(".//text()[. = 'Games Tied']/../..")[0][1].text
+            ties = int(game_box.xpath(".//text()[. = 'Games Tied']/../..")[0][1].text
                        .replace(",", ""))
         except IndexError:
             # Sometimes the losses and ties don't exist.


### PR DESCRIPTION
I believe this fixes #257 as well as fixing the tie count for competitive. @Doezer mentions that Blizzard made the boxes random, but that doesn't seem to be the case for me. Perhaps they have made more changes since then.