### PR TITLE
#272 - Handle parsing errors when there are no stats boxes for a hero.

### DIFF
--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -445,10 +445,15 @@ def bl_parse_hero_data(parsed: etree._Element, mode="quickplay"):
         subbox_offset = 0
 
         # .find on the assumption hero box is the *first* item
+        hbtitle = None
         try:
             hbtitle = stat_groups.find(".//span[@class='stat-title']").text
         except AttributeError:
-            hbtitle = stat_groups.find(".//h5[@class='stat-title']").text
+            try:
+                hbtitle = stat_groups.find(".//h5[@class='stat-title']").text
+            except AttributeError:
+                # Unable to parse stat boxes. This is likely due to 0 playtime on a hero, so there are no stats
+                pass
         if hbtitle == "Hero Specific":
             subbox_offset = 1
             hero_specific_box = stat_groups[0]


### PR DESCRIPTION
In certain cases, a player can end up with playtime registered on a hero, but 0 playtime, and no statistics. This results in the Career Stats block being completely empty, resulting in a parsing failure and a 500 error.

This simply ignores these errors, as we can't really do anything about them, and allows us to return the rest of the data.