### PR TITLE
Added new Tier System

### DIFF
--- a/owapi/v3/parsing.py
+++ b/owapi/v3/parsing.py
@@ -205,10 +205,19 @@ def bl_parse_stats(parsed, mode="quickplay", status=None):
             else:
                 comprank = None
             built_dict["overall_stats"][role_str + "_comprank"] = comprank
-    except IndexError:
-        built_dict['overall_stats']['tank_tier'] = None
-        built_dict['overall_stats']['damage_tier'] = None
-        built_dict['overall_stats']['support_tier'] = None
+            
+    except IndexError as exc:
+        print(str(exc))
+    finally:
+        for role in ['tank', 'damage', 'support']:
+            if role + "_role_image" not in built_dict['overall_stats']:
+                built_dict['overall_stats'][role + '_role_image'] = None
+            if role + "_tier_image" not in built_dict['overall_stats']:
+                built_dict['overall_stats'][role + '_tier_image'] = None
+            if role + "_tier" not in built_dict['overall_stats']:
+                built_dict['overall_stats'][role + '_tier'] = None
+            if role + "_comprank" not in built_dict['overall_stats']:
+                built_dict['overall_stats'][role + '_comprank'] = None
 
     # Fetch Avatar
     built_dict["overall_stats"]["avatar"] = mast_head.find(


### PR DESCRIPTION
Hi there!
I spent some time to figure out the new tier system and implement it in OWAPI.
They also changed the HTML formatting of the endorsement Level, which I also fixed here.

I tried to make the "competitive rank" section a little more "safe" by implementing nearly the whole section into a try catch.

So, what will the results look like?

If the player has not played any Competitive at all the overall_stats will look like this:

```
"overall_stats": {
    ...
    "tank_tier": null,
    "damage_tier": null,
    "support_tier": null,
    ...
},
```

If the player only has a competitive rank in one or two roles only these roles will be determined!

So Stats could look like this:

```
"overall_stats": {
    ...
    "tank_role_image": "https://static.playoverwatch.com/img/pages/career/icon-tank-8a52daaf01.png",
    "tank_tier_image": "https://d1u1mce87gyfbn.cloudfront.net/game/rank-icons/rank-DiamondTier.png",
    "tank_tier": "diamond",
    "tank_comprank": 3363,
    "support_role_image": "https://static.playoverwatch.com/img/pages/career/icon-support-46311a4210.png",
    "support_tier_image": "https://d1u1mce87gyfbn.cloudfront.net/game/rank-icons/rank-PlatinumTier.png",
    "support_tier": "platinum",
    "support_comprank": 2927,
    ...
},
```

You see that there is no "damage_" section what is ok, because the player has no rank as a damage dealer.

The roles will start with these values:
- damage
- tank
- support

If a role is found there are always these values:
- [ROLE]_role_image: the icon of the role like the shield for tank or the plus for support
- [ROLE]_tier_image: the image of the tier like the diamond sign or the master sign
- [ROLE]_tier: the name of the tier like "diamond" or "master"
- [ROLE]_comprank: the rank value as integer of the player in the specific role

What I also fixed here is a "format(mode)" which does not do anything because the string does not need any formatting.